### PR TITLE
Use primary branch name in docker gh-actions plugins

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,16 +31,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@main
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@master
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@master
       - name: Build and push latest
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@master
         with:
           context: ./
           file: dockerfiles/${{ matrix.dockerfile }}


### PR DESCRIPTION
 * We can't always check about docker gh-actions plugins update.
 * So, Just use primary branch name in docker gh-actions plugins to avoid it.